### PR TITLE
Small modifications to improve building process in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,12 @@ project (a.multiminer C ASM CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR})
 
-# Windows build additional configuration
-# set(DEPRECATION_FLAGS "-Xlinker --allow-multiple-definition -Wno-error=deprecated")
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAGS}")
-# set(C_DEP_FLAGS "-Wno-pointer-sign -Wno-pointer-to-int-cast")
-# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_DEP_FLAGS}")
-# set(NO_CUDA TRUE)
+IF (WIN32 AND NOT MSVC)
+    set(DEPRECATION_FLAGS "-Xlinker --allow-multiple-definition -w")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAGS}")
+    set(C_DEP_FLAGS "-w")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_DEP_FLAGS}")
+ENDIF()
 
 SET(CMAKE_SKIP_BUILD_RPATH FALSE)
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
@@ -310,8 +310,12 @@ target_link_libraries(a.multiminer mm_gpu_gate ${CMAKE_THREAD_LIBS_INIT} ${CURL_
 IF (WIN32)
 	target_link_libraries(a.multiminer -lws2_32)
 ENDIF()
-# Windows build works with O1 instead of O3
-target_compile_options(a.multiminer PRIVATE -O3 -mtune=native -march=native -I.)
+
+IF (WIN32)
+     target_compile_options(a.multiminer PRIVATE -O1 -mtune=native -march=native -I.)
+ELSE()
+     target_compile_options(a.multiminer PRIVATE -O3 -mtune=native -march=native -I.)
+ENDIF()
 
 IF (BUILD_ALL_ARCH)
 	add_executable(a.multiminer-sse2 ${SOURCE})


### PR DESCRIPTION
This is a fast solution I found for Windows compilation with newest versions of gcc (Ex: gcc v11.2.0)

Edit CMakeLists.txt:

```
IF (WIN32 AND NOT MSVC)
    set(DEPRECATION_FLAGS "-Xlinker --allow-multiple-definition -w")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEPRECATION_FLAGS}")
    set(C_DEP_FLAGS "-w")
    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_DEP_FLAGS}")
ENDIF()
```

And at line 314

```
IF (WIN32)
     target_compile_options(a.multiminer PRIVATE -O1 -mtune=native -march=native -I.)
ELSE()
     target_compile_options(a.multiminer PRIVATE -O3 -mtune=native -march=native -I.)
ENDIF()
```

Use cmake with the extra params to remove some warnings and setup NO_CUDA var here to avoid editing CMakeLists.txt file:

`cmake .. -Wno-dev -DNO_CUDA=TRUE -G "MinGW Makefiles"`